### PR TITLE
Add support for adding option to subcommand

### DIFF
--- a/spec/CommanderSpec.php
+++ b/spec/CommanderSpec.php
@@ -206,6 +206,24 @@ class CommanderSpec extends ObjectBehavior
             ->action(function(){});
     }
 
+    function it_can_add_option_to_command()
+    {
+        $program = $this->getWrappedObject();
+        $this->command('rmdir <dir> [otherDirs...]', 'Remove the directory')
+            ->option('-r, --recursive', 'Remove recursively')
+            ->action(function() use ($program) {
+                foreach ($program->_subCmds as $cmd) {
+                    if ($cmd->_name == 'rmdir') {
+                        return $cmd->recursive ? 'recursive' : 'flat';
+                    }
+                }
+            });
+
+        $argv = ['test.php', 'rmdir', 'testDir', '-r'];
+
+        $this->parse($argv)->shouldReturn('recursive');
+    }
+
     function it_will_throw_exception_if_missing_a_required_arg_for_a_command()
     {
         $this->command('rmdir <dir> [otherDirs...]', 'Remove the directory')

--- a/src/Commander.php
+++ b/src/Commander.php
@@ -96,18 +96,20 @@ class Commander
 
         $this->_args = $this->normalize(array_slice($argv, 1));
 
-        $this->parseOptions($this->_args);
-
         if (count($this->_args) > 0) {
             $name = $this->_args[0];
 
             if ($name[0] !== '-') {
                 foreach ($this->_subCmds as $cmd) {
                     if ($cmd->_name == $name) {
-                        array_shift($this->_unknownArgs);
-                        return $this->triggerCmd($cmd);
+                        $cmd->parseOptions($this->_args);
+                        array_shift($cmd->_unknownArgs);
+                        return $cmd->triggerCmd($cmd);
                     }
                 }
+            }
+            else {
+                $this->parseOptions($this->_args);
             }
         }
     }


### PR DESCRIPTION
Implements adding option to sub command, following is an example:

```php
$program = new Commander();

$program
    ->version('0.0.1');

$program
    ->command('rmdir <dir>', 'remove dir')
    ->option('-r, --recursive', 'remove recursively')
    ->action(
        function ($dir) use ($program) {
            foreach ($program->_subCmds as $cmd) {
                if ($cmd->_name == 'rmdir') {
                    if ($cmd->recursive) {
                        // recursively implement goes here...
                    }
                    else {
                        // normal implement goes here...
                    }
                    break;
                }
            }
        }
    );

$program->parse($argv);
```